### PR TITLE
Add SITE_BASE_PATH alias for FORCE_SCRIPT_NAME

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ HOST_URL=localhost
 ALLOWED_HOSTS=localhost,127.0.0.1
 HOST_PORT=8000
 CONTAINER_PORT=$HOST_PORT
+SITE_BASE_PATH=
+# Used to set Django's FORCE_SCRIPT_NAME when serving the site under a sub-path
+USE_WHITENOISE=0
 SITE_NAME="Sites faciles"
 MEDIA_ROOT=medias
 

--- a/content_manager/management/commands/create_starter_pages.py
+++ b/content_manager/management/commands/create_starter_pages.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.urls import reverse

--- a/content_manager/templatetags/wagtail_dsfr_tags.py
+++ b/content_manager/templatetags/wagtail_dsfr_tags.py
@@ -25,6 +25,7 @@ def mega_menu(context: Context, parent_menu_id: int) -> dict:
 def settings_value(name):
     return getattr(settings, name, "")
 
+
 @register.simple_tag
 def root_url() -> str:
     """Return the site's base path, taking ``FORCE_SCRIPT_NAME`` into account."""
@@ -32,8 +33,6 @@ def root_url() -> str:
     if script:
         return f"{script}/"
     return "/"
-
-
 
 
 @register.simple_tag(takes_context=True)
@@ -58,7 +57,7 @@ def canonical_url(context):
         if site.port != 80:
             hostname = f"{hostname}:{site.port}"
     else:
-        hostname = request.get_host
+        hostname = request.get_host()
 
     return f"{scheme}://{hostname}{request.path}"
 

--- a/dashboard/wagtail_hooks.py
+++ b/dashboard/wagtail_hooks.py
@@ -1,8 +1,8 @@
+from django.conf import settings
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import escape, format_html
 from django.utils.translation import gettext_lazy as _
-from django.conf import settings
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.rich_text import LinkHandler
@@ -29,7 +29,7 @@ def insert_custom_editor_scripts():
 
 @hooks.register("register_admin_menu_item")
 def register_site_menu_item():
-    index_url = f"{settings.FORCE_SCRIPT_NAME or ''}/"    
+    index_url = f"{settings.FORCE_SCRIPT_NAME or ''}/"
     return MenuItem(
         _("Visit site"),
         index_url,


### PR DESCRIPTION
## Summary
- keep environment variable `SITE_BASE_PATH` and compute Django `FORCE_SCRIPT_NAME`
- use `FORCE_SCRIPT_NAME` throughout the codebase
- document relationship in `.env.example`
- allow toggling WhiteNoise with `USE_WHITENOISE`

## Testing
- `pre-commit run --files .env.example config/settings.py content_manager/templatetags/wagtail_dsfr_tags.py content_manager/views.py dashboard/wagtail_hooks.py content_manager/management/commands/create_starter_pages.py`
- `make test-unit` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68667c54e614832d828f2ff0b3279f15